### PR TITLE
Task 3: Undo add and remove from reading list

### DIFF
--- a/apps/okreads-e2e/src/integration/reading-list.spec.ts
+++ b/apps/okreads-e2e/src/integration/reading-list.spec.ts
@@ -1,6 +1,8 @@
 describe('When: I use the reading list feature', () => {
+  let count = 0;
   beforeEach(() => {
     cy.startAt('/');
+    count = cy.$$('[data-testing="reading-list-item"]').length;
   });
 
   it('Then: I should see my reading list', () => {
@@ -10,5 +12,44 @@ describe('When: I use the reading list feature', () => {
       'contain.text',
       'My Reading List'
     );
+  });
+
+  it('Then: I should be able to add book and undo added book', () => {
+
+    cy.get('input[type="search"]').type('Liferay In Action');
+
+    cy.get('form').submit();
+
+    cy.get('[data-testing="add-to-reading-list"]:enabled').first().click();
+
+    cy.get('[data-testing="reading-list-item"]').should('have.length', count + 1);
+
+    cy.get('.mat-simple-snackbar-action button').click();
+
+    cy.get('[data-testing="reading-list-item"]').should('have.length', count);
+
+  });
+
+  it('Then: I should be able to remove book and undo removed book', () => {
+    cy.get('input[type="search"]').type('Gradle in Action');
+
+    cy.get('form').submit();
+
+    cy.get('[data-testing="add-to-reading-list"]:enabled').first().click();
+
+    cy.get('[data-testing="reading-list-item"]').should('have.length', count + 1);
+
+    cy.get('[data-testing="toggle-reading-list"]').click();
+
+    cy.get('[data-testing="remove-book"]:enabled').first().click();
+
+    cy.get('[data-testing="close-reading-list"]').click();
+
+    cy.get('[data-testing="reading-list-item"]').should('have.length', count);
+
+    //undo remove from reading list
+    cy.get('.mat-simple-snackbar-action button').click();
+
+    cy.get('[data-testing="reading-list-item"]').should('have.length', count + 1);
   });
 });

--- a/apps/okreads-e2e/src/integration/reading-list.spec.ts
+++ b/apps/okreads-e2e/src/integration/reading-list.spec.ts
@@ -50,6 +50,6 @@ describe('When: I use the reading list feature', () => {
     //undo remove from reading list
     cy.get('.mat-simple-snackbar-action button').click();
 
-    cy.get('[data-testing="reading-list-item"]').should('have.length', count + 1);
+   cy.get('[data-testing="reading-list-item"]', { multiple: true }).should('have.length', count + 1);
   });
 });

--- a/apps/okreads/browser/src/app/app.component.html
+++ b/apps/okreads/browser/src/app/app.component.html
@@ -24,7 +24,7 @@
     <div class="reading-list-container" data-testing="reading-list-container">
       <h2>
         My Reading List
-        <button mat-icon-button (click)="drawer.close()">
+        <button data-testing="close-reading-list" mat-icon-button (click)="drawer.close()">
           <mat-icon>close</mat-icon>
         </button>
       </h2>

--- a/libs/books/data-access/src/lib/+state/reading-list.effects.spec.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.effects.spec.ts
@@ -1,22 +1,31 @@
-import { TestBed } from '@angular/core/testing';
 import { ReplaySubject } from 'rxjs';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
-
-import { SharedTestingModule } from '@tmo/shared/testing';
+import { fakeAsync, TestBed } from '@angular/core/testing';
 import { ReadingListEffects } from './reading-list.effects';
 import * as ReadingListActions from './reading-list.actions';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { Book, ReadingListItem } from '@tmo/shared/models';
+import { createBook, createReadingListItem, SharedTestingModule } from '@tmo/shared/testing';
 
 describe('ToReadEffects', () => {
+  let book: Book;
   let actions: ReplaySubject<any>;
   let effects: ReadingListEffects;
   let httpMock: HttpTestingController;
-
+  let item: ReadingListItem
+  const snackBar: MatSnackBar = null;
+  beforeAll(() => {
+    item = createReadingListItem('A');
+    book = createBook('A');
+  })
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SharedTestingModule],
-      providers: [
+      imports: [
+        SharedTestingModule,
+        MatSnackBarModule
+      ], providers: [
         ReadingListEffects,
         provideMockActions(() => actions),
         provideMockStore()
@@ -41,5 +50,64 @@ describe('ToReadEffects', () => {
 
       httpMock.expectOne('/api/reading-list').flush([]);
     });
+  });
+
+
+  describe('addBook$', () => {
+    it('Should add a book to the reading list', fakeAsync(() => {
+      actions.next(ReadingListActions.addToReadingList({ book }));
+
+      effects.addBook$.subscribe(action => {
+        expect(action).toEqual(
+          ReadingListActions.confirmedAddToReadingList({ book })
+        );
+      })
+
+      httpMock.expectOne('/api/reading-list').flush({});
+    }));
+
+    it('Show the snack bar ahile adding a book', async () => {
+      actions = new ReplaySubject();
+      actions.next(ReadingListActions.confirmedAddToReadingList({ book }));
+
+      effects.undoAddtoReadingList$.subscribe(() => {
+        snackBar.open(`Added ${book.title} to reading list`, 'Undo', { duration: 2000 }).onAction().subscribe((action) => {
+          expect(action).toEqual(
+            ReadingListActions.removeFromReadingList({ item })
+          )
+        })
+      });
+    });
+
+  });
+
+  describe('removeBook$', () => {
+    it('Should remove a book from reading list', done => {
+      actions.next(ReadingListActions.removeFromReadingList({ item }));
+
+      effects.removeBook$.subscribe(action => {
+        expect(action).toEqual(
+          ReadingListActions.confirmedRemoveFromReadingList({ item })
+        );
+
+        done();
+      });
+
+      httpMock.expectOne(`/api/reading-list/${item.bookId}`).flush({});
+    });
+
+    it('Show the snack bar while removing a book', async () => {
+      actions = new ReplaySubject();
+      actions.next(ReadingListActions.confirmedRemoveFromReadingList({ item }));
+
+      effects.undoRemoveFromReadingList$.subscribe(() => {
+        snackBar.open(`Removed ${item.title} to reading list`, 'Undo', { duration: 1000 }).onAction().subscribe((action) => {
+          expect(action).toEqual(
+            ReadingListActions.addToReadingList({ book })
+          );
+        })
+      });
+    });
+
   });
 });

--- a/libs/books/data-access/src/lib/+state/reading-list.effects.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.effects.ts
@@ -94,7 +94,7 @@ export class ReadingListEffects implements OnInitEffects {
 
   openSnackBar(item: ReadingListItem | Book, message: string, isAdded: boolean): void {
     this.snackBar.open(message, 'UNDO', {
-      duration: 5000
+      duration: 3000
     })
       .onAction()
       .subscribe(() =>

--- a/libs/books/data-access/src/lib/+state/reading-list.effects.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.effects.ts
@@ -2,9 +2,14 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Actions, createEffect, ofType, OnInitEffects } from '@ngrx/effects';
 import { of } from 'rxjs';
-import { catchError, concatMap, exhaustMap, map } from 'rxjs/operators';
-import { ReadingListItem } from '@tmo/shared/models';
+
 import * as ReadingListActions from './reading-list.actions';
+import { catchError, concatMap, exhaustMap, map, filter } from 'rxjs/operators';
+import { Book, ReadingListItem } from '@tmo/shared/models';
+
+
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Store } from '@ngrx/store';
 import { ENDPOINT_URL } from '../constants';
 
 @Injectable()
@@ -55,9 +60,62 @@ export class ReadingListEffects implements OnInitEffects {
     )
   );
 
+
+
+  undoAddtoReadingList$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(ReadingListActions.confirmedAddToReadingList),
+      filter(({ book }) => book.snackBar),
+      map(({ book }) =>
+        this.openSnackBar(
+          { ...book, bookId: book.id, snackBar: false },
+          `${book.title}: added to the  reading list`,
+          true
+        )
+      ),
+    ),
+    { dispatch: false }
+  );
+
+  undoRemoveFromReadingList$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(ReadingListActions.confirmedRemoveFromReadingList),
+      filter(({ item }) => item.snackBar),
+      map(({ item }) =>
+        this.openSnackBar(
+          { ...item, id: item.bookId, snackBar: false },
+          `${item.title}: removed from the reading list`,
+          false
+        )
+      )
+    ),
+    { dispatch: false }
+  );
+
+  openSnackBar(item: ReadingListItem | Book, message: string, isAdded: boolean): void {
+    this.snackBar.open(message, 'UNDO', {
+      duration: 5000
+    })
+      .onAction()
+      .subscribe(() =>
+        isAdded ?
+          this.store.dispatch(
+            ReadingListActions.removeFromReadingList({
+              item: item as ReadingListItem
+            })
+          ) :
+          this.store.dispatch(
+            ReadingListActions.addToReadingList({
+              book: item as Book
+            })
+          )
+      )
+  }
+
   ngrxOnInitEffects() {
     return ReadingListActions.init();
   }
 
-  constructor(private actions$: Actions, private http: HttpClient) { }
+  constructor(private actions$: Actions, private http: HttpClient, private readonly snackBar: MatSnackBar,
+    private readonly store: Store) { }
 }

--- a/libs/books/feature/src/lib/book-search/book-search.component.html
+++ b/libs/books/feature/src/lib/book-search/book-search.component.html
@@ -15,7 +15,7 @@
 
 <ng-container *ngIf="searchTerm; else empty">
   <div class="book-grid">
-    <div class="book" data-testing="book-item" *ngFor="let b of books">
+    <div class="book" data-testing="book-item" *ngFor="let b of books$ | async">
       <div class="book--title">
         {{ b.title }}
       </div>
@@ -33,6 +33,7 @@
           <div>
             <button
               aria-label="Want to Read"
+              data-testing="add-to-reading-list"
               mat-flat-button
               color="primary"
               (click)="addBookToReadingList(b)"

--- a/libs/books/feature/src/lib/book-search/book-search.component.ts
+++ b/libs/books/feature/src/lib/book-search/book-search.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import {
   addToReadingList,
@@ -9,61 +9,49 @@ import {
 } from '@tmo/books/data-access';
 import { FormBuilder } from '@angular/forms';
 import { Book } from '@tmo/shared/models';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'tmo-book-search',
   templateUrl: './book-search.component.html',
-  styleUrls: ['./book-search.component.scss']
+  styleUrls: ['./book-search.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class BookSearchComponent implements OnInit,OnDestroy {
+export class BookSearchComponent implements OnInit, OnDestroy {
   private subscription;
-  books: ReadingListBook[];
-
-  searchForm = this.fb.group({
-    term: ''
-  });
-
   constructor(
     private readonly store: Store,
-    private readonly fb: FormBuilder
-  ) {}
+    private readonly form: FormBuilder
+  ) { }
+  books$: Observable<ReadingListBook[]> = this.store.select(getAllBooks);
+  searchForm = this.form.group({
+    term: ''
+  });
 
   get searchTerm(): string {
     return this.searchForm.value.term;
   }
 
-  ngOnInit(): void {
-    this.subscription = this.store.select(getAllBooks).subscribe(books => {
-      this.books = books;
-    });
+  addBookToReadingList(book: Book): void {
+    this.store.dispatch(addToReadingList({ book: { ...book, snackBar: true } }));
   }
 
-  ngOnDestroy(): void {
-    if (this.subscription) {
-      this.subscription.unsubscribe();
-    }
-  }
-
-  formatDate(date: void | string) {
-    return date
-      ? new Intl.DateTimeFormat('en-US').format(new Date(date))
-      : undefined;
-  }
-
-  addBookToReadingList(book: Book) {
-    this.store.dispatch(addToReadingList({ book }));
-  }
-
-  searchExample() {
+  searchExample(): void {
     this.searchForm.controls.term.setValue('javascript');
     this.searchBooks();
   }
 
-  searchBooks() {
+  searchBooks(): void {
     if (this.searchForm.value.term) {
       this.store.dispatch(searchBooks({ term: this.searchTerm }));
     } else {
       this.store.dispatch(clearSearch());
     }
   }
+  ngOnInit() { }
+  ngOnDestroy() {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
+   }
 }

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.html
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="(readingList$ | async).length > 0; else empty">
-  <div class="reading-list-item" *ngFor="let book of readingList$ | async">
+  <div class="reading-list-item" data-testing="reading-list-item" *ngFor="let book of readingList$ | async">
     <div>
       <img alt="book cover" class="reading-list-item--cover" [src]="book.coverUrl" />
     </div>
@@ -11,6 +11,7 @@
     </div>
     <div>
       <button
+        data-testing="remove-book"
         mat-icon-button
         color="warn"
         [attr.aria-label]="'Remove ' + book.title + ' from reading list'"

--- a/libs/shared/models/src/models.ts
+++ b/libs/shared/models/src/models.ts
@@ -6,6 +6,7 @@ export interface Book {
   publisher?: string;
   publishedDate?: string;
   coverUrl?: string;
+  snackBar?:boolean
 }
 
 export interface ReadingListItem extends Omit<Book, 'id'> {


### PR DESCRIPTION
- Implemented Undo Feature for Want to Read and Remove Actions
- The task was focused on providing users with the ability to quickly undo their actions when interacting with the "Want to Read" button in the book list or the remove button in the reading list.
npm run lint(Video):

https://github.com/hamidul/tmo-web-ui-developer-puzzle/assets/1208212/ed697b7b-8afd-4937-8551-ef7126d72028


npm run test(Video):

https://github.com/hamidul/tmo-web-ui-developer-puzzle/assets/1208212/f5caadc8-4a31-4b2a-b15d-b4120358af86


npm run e2e(Video):


https://github.com/hamidul/tmo-web-ui-developer-puzzle/assets/1208212/a2e67f97-703c-46b0-88fd-ac87b1cef998



